### PR TITLE
fix: use tidev for remote_path

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "binary": {
     "module_name": "node_ios_device",
     "module_path": "./binding/{node_abi}-{platform}-{arch}/",
-    "remote_path": "./appcelerator/{name}/releases/download/v{version}",
+    "remote_path": "./tidev/{name}/releases/download/v{version}",
     "host": "https://github.com",
     "targets": {
       "10.16.3": 64,


### PR DESCRIPTION
This is needed because the HTTP client used by node-pre-gyp doesn't handle redirects