### PR TITLE
ci: use macos-13 to run ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    # Specify macos-13 because we need to build on an x64 machine and all macos 14 machines are arm based.
+    # There seems to be an issue building x64 variants on arm64 machines.
+    runs-on: macos-13
     name: Build
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   publish:
-    runs-on: macos-latest
+    # Specify macos-13 because we need to build on an x64 machine and all macos 14 machines are arm based.
+    # There seems to be an issue building x64 variants on arm64 machines.
+    runs-on: macos-13
     name: Publish
 
     steps:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-ios-device",
   "description": "Simple library for listing and installing apps on iOS devices",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": "TiDev, Inc. <tisdk@cb1inc.com>",
   "maintainers": [
     "Chris Barber <chris@cb1inc.com>"


### PR DESCRIPTION
There seems to be an issue with compiling node-ios-device for x64 on arm64 machines, unfortunately all MacOS 14 runners on GitHub are now arm64 based so we have to drop down to MacOS 13. We can verify it builds ok using the artifacts produced.

Realistically, this is a bandaid not a fix. There might be a genuine fix we can perform in the build logic but this is hopefully faster.