### PR TITLE
BREAKING CHANGE: Remove default export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 ._*
 .DS_Store
 .nyc_output
+.pnpm-store
 *.tgz
 /build
+coverage
 dist
 env.properties
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v7.0.0 (Jul 1, 2026)
+
+- BREAKING CHANGE: Remove default export. Use `import { IOSDevice } from 'node-ios-device'` instead.
+- chore: Updated dependencies.
+
 # v6.0.2 (Jul 1, 2026)
 
 - fix: Set correct export paths for ESM and CJS.

--- a/bin/node-ios-device
+++ b/bin/node-ios-device
@@ -21,7 +21,8 @@ if (args.values.version) {
 	process.exit(0);
 }
 
-const { iosDevice } = await import('../dist/index.mjs');
+const { IOSDevice } = await import('../dist/index.mjs');
+const iosDevice = new IOSDevice();
 
 function selectDevice(udid) {
 	if (udid) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ios-device",
-  "version": "6.0.2",
+  "version": "7.0.0",
   "description": "Simple library for detecting and installing apps on iOS devices",
   "keywords": [
     "device",
@@ -54,10 +54,10 @@
   },
   "dependencies": {
     "node-gyp-build": "4.8.4",
-    "snooplogg": "7.0.1"
+    "snooplogg": "8.0.0"
   },
   "devDependencies": {
-    "@types/node": "26.0.1",
+    "@types/node": "26.1.0",
     "@vitest/coverage-v8": "4.1.9",
     "lefthook": "2.1.9",
     "node-gyp": "13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,12 +12,12 @@ importers:
         specifier: 4.8.4
         version: 4.8.4
       snooplogg:
-        specifier: 7.0.1
-        version: 7.0.1
+        specifier: 8.0.0
+        version: 8.0.0
     devDependencies:
       '@types/node':
-        specifier: 26.0.1
-        version: 26.0.1
+        specifier: 26.1.0
+        version: 26.1.0
       '@vitest/coverage-v8':
         specifier: 4.1.9
         version: 4.1.9(vitest@4.1.9)
@@ -50,7 +50,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.0.1))
+        version: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.1.0))
 
 packages:
 
@@ -788,8 +788,8 @@ packages:
   '@types/jsesc@2.5.1':
     resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
 
-  '@types/node@26.0.1':
-    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@vitest/coverage-v8@4.1.9':
     resolution: {integrity: sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==}
@@ -1244,8 +1244,8 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  snooplogg@7.0.1:
-    resolution: {integrity: sha512-bk31dQ/ig9J7LjBj80JZ35BQjtHc3M0xQAHkCKxdE4BpDDodPHnfAZvxbjdIl14PUasTSjFMJ1h9XdmyrTW0UA==}
+  snooplogg@8.0.0:
+    resolution: {integrity: sha512-1CRzAkfUJDADXabueNizFqsGb7XPi/w89s78bAAESUF3ipQUI/daMWtMEQgpyySV+iEWLS/JkJEJXxzpIV3zsA==}
     engines: {node: '>=18.17'}
 
   source-map-js@1.2.1:
@@ -1882,7 +1882,7 @@ snapshots:
 
   '@types/jsesc@2.5.1': {}
 
-  '@types/node@26.0.1':
+  '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -1898,7 +1898,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.0.1))
+      vitest: 4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.1.0))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -1909,13 +1909,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@7.3.1(@types/node@26.0.1))':
+  '@vitest/mocker@4.1.9(vite@7.3.1(@types/node@26.1.0))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@26.0.1)
+      vite: 7.3.1(@types/node@26.1.0)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -2377,7 +2377,7 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  snooplogg@7.0.1: {}
+  snooplogg@8.0.0: {}
 
   source-map-js@1.2.1: {}
 
@@ -2478,7 +2478,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.1(@types/node@26.0.1):
+  vite@7.3.1(@types/node@26.1.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2487,13 +2487,13 @@ snapshots:
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.0
       fsevents: 2.3.3
 
-  vitest@4.1.9(@types/node@26.0.1)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.0.1)):
+  vitest@4.1.9(@types/node@26.1.0)(@vitest/coverage-v8@4.1.9)(vite@7.3.1(@types/node@26.1.0)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@7.3.1(@types/node@26.0.1))
+      '@vitest/mocker': 4.1.9(vite@7.3.1(@types/node@26.1.0))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -2510,10 +2510,10 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.1(@types/node@26.0.1)
+      vite: 7.3.1(@types/node@26.1.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.0
       '@vitest/coverage-v8': 4.1.9(vitest@4.1.9)
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,5 @@ allowBuilds:
   esbuild: true
   lefthook: true
 minimumReleaseAgeExclude:
-  - snooplogg@7.0.1
+  - snooplogg@7.0.1 || 8.0.0
+  - '@types/node@26.1.0'

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'node:events';
 import { readdirSync, statSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
-import snooplogg from 'snooplogg';
+import { snooplogg } from 'snooplogg';
 
 const logger = snooplogg('node-ios-device');
 const nss = {};
@@ -72,7 +72,7 @@ export class WatchHandle extends EventEmitter {
 	}
 }
 
-export type IOSDevice = {
+export type DeviceInfo = {
 	udid: string;
 	interfaces: ('USB' | 'Wi-Fi')[];
 	name: string;
@@ -88,7 +88,7 @@ export type IOSDevice = {
 	trustedHostAttached: boolean;
 };
 
-export class NodeIOSDevice extends EventEmitter {
+export class IOSDevice extends EventEmitter {
 	constructor() {
 		super();
 
@@ -164,7 +164,7 @@ export class NodeIOSDevice extends EventEmitter {
 	 *
 	 * @returns {Array.<Object>}
 	 */
-	list(): ReadonlyArray<IOSDevice> {
+	list(): ReadonlyArray<DeviceInfo> {
 		return binding.list();
 	}
 
@@ -178,12 +178,3 @@ export class NodeIOSDevice extends EventEmitter {
 		return new WatchHandle();
 	}
 }
-
-/**
- * The `node-ios-device` API and debug log emitter.
- *
- * @type {NodeIOSDevice}
- * @emits {log} Emits a debug log message.
- */
-export const iosDevice = new NodeIOSDevice();
-export default iosDevice;

--- a/test/node-ios-device.test.ts
+++ b/test/node-ios-device.test.ts
@@ -1,4 +1,4 @@
-import iosDevice from '../src/index.js';
+import { IOSDevice } from '../src/index.js';
 import { spawnSync } from 'node:child_process';
 import { join, resolve } from 'node:path';
 import { assert, describe, expect, it } from 'vitest';
@@ -6,6 +6,7 @@ import { assert, describe, expect, it } from 'vitest';
 const __dirname = import.meta.dirname;
 const appPath = resolve(__dirname, 'TestApp', 'build', 'Release-iphoneos', 'TestApp.app');
 
+const iosDevice = new IOSDevice();
 let udid: string | null = null;
 let usbUDID: string | null = null;
 let wifiUDID: string | null = null;


### PR DESCRIPTION
- BREAKING CHANGE: Remove default export. Use `import { IOSDevice } from 'node-ios-device'` instead.
- chore: Updated dependencies.